### PR TITLE
Doc example improvement

### DIFF
--- a/docs/metadata/README.md
+++ b/docs/metadata/README.md
@@ -1,0 +1,64 @@
+# T2 CLI Documentation Examples
+
+This document explains how the files in this directory are used, and how to add new documentation examples.
+
+## How does it work?
+The AG Grid examples loosely follow this format:
+
+`https://www.ag-grid.com/examples/<page>/<example>/<ag-grid-installation-method>/<framework>/<file>`.
+
+For example, to add the [Range Selection](https://www.ag-grid.com/react-data-grid/range-selection/#example-range-selection) example, the URL is:
+
+`https://www.ag-grid.com/examples/range-selection/range-selection/packages/react/index.html`
+
+The above link tells us that the URL is pointing to the `index.html` file for React using AG Grid Packages.
+
+If we wanted to get the `index.jsx` using AG Grid Modules, we can change the link to the following:
+
+`https://www.ag-grid.com/examples/range-selection/range-selection/modules/react/index.jsx`
+
+In short, this means that as long as we have a partial URL link to the example (`https://www.ag-grid.com/examples/range-selection/range-selection`), we can dynamically get a file (`index.js`, `styles.css`, `app.component.ts`) for any framework (`vanilla`/`vue`/`angular`/`react`), built in Packages or Modules (`packages`/`modules`), simply by changing these values.
+
+## Adding Documentation Examples to the CLI
+To add a new example to the CLI, open `docs-core.json` and add the partial URL (strip away the framework and the file extension) for the example to the `baseURL` property.
+
+For example, for Range Selection, the partial URL is:
+
+`https://www.ag-grid.com/examples/range-selection/range-selection/packages`.
+
+So we add the example like this:
+```json
+{
+    "baseURL": {
+        "range-selection": "https://www.ag-grid.com/examples/range-selection/range-selection/packages",
+    }
+}
+```
+
+By default, the CLI knows to get a list of default files for every framework because every example in the documentation has them, you can view these inside `docs-core.json` under the `filesToFetch` for a given framework.
+
+When there are extra files for the CLI to import that aren't listed inside `docs-core.json`, you have to define it in the json file for that example.
+
+For example, Range Selection has a file `range-selection.json` which contains a list of extra files to import:
+
+```json
+{
+    "react": {
+        "filesToFetch": []
+    },
+    "angular": {
+        "filesToFetch": [
+            {
+                "url": "app/interfaces.ts",
+                "destination": "src/app/interfaces.ts"
+            }
+        ]
+    },
+    "vue": {
+        "filesToFetch": []
+    },
+    "vanilla": {
+        "filesToFetch": []
+    }
+}
+```

--- a/docs/metadata/docs-core.json
+++ b/docs/metadata/docs-core.json
@@ -1,0 +1,69 @@
+{
+    "baseURL": {
+        "range-selection": "https://www.ag-grid.com/examples/range-selection/range-selection/packages",
+        "row-grouping": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages",
+        "server-side-row-model": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages",
+        "tree-data": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages",
+        "master-detail": "https://www.ag-grid.com/examples/master-detail/simple/packages",
+        "master-detail-custom-detail-grid": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages"
+    },
+    "react": {
+        "frameworkPath": "reactFunctional",
+        "filesToFetch": [
+            {
+                "url": "index.jsx",
+                "destination": "src/index.js"
+            }
+        ],
+        "filesToRemoveFromTemplate": [
+            "src/App.js",
+            "src/App.css",
+            "src/App.test.js",
+            "src/logo.svg",
+            "src/index.css"
+        ]
+    },
+    "angular": {
+        "frameworkPath": "angular",
+        "filesToFetch": [
+            {
+                "url": "app/app.component.ts",
+                "destination": "src/app/app.component.ts"
+            },
+            {
+                "url": "app/app.module.ts",
+                "destination": "src/app/app.module.ts"
+            }
+        ],
+        "filesToRemoveFromTemplate": [
+            "src/app/app.component.html",
+            "src/app/app.component.scss"
+        ]
+    },
+    "vue": {
+        "frameworkPath": "vue",
+        "filesToFetch": [
+            {
+                "url": "main.js",
+                "destination": "src/main.js"
+            }
+        ],
+        "filesToRemoveFromTemplate": [
+            "src/assets",
+            "src/components",
+            "src/App.vue"
+        ]
+    },
+    "vanilla": {
+        "frameworkPath": "vanilla",
+        "filesToFetch": [
+            {
+                "url": "main.js",
+                "destination": "src/index.js"
+            }
+        ],
+        "filesToRemoveFromTemplate": [
+            "src/styles.css"
+        ]
+    }
+}

--- a/docs/metadata/master-detail-custom-detail-grid.json
+++ b/docs/metadata/master-detail-custom-detail-grid.json
@@ -1,93 +1,54 @@
 {
     "react": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/reactFunctional/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/reactFunctional/index.jsx",
-                "destination": "src/index.js"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/reactFunctional/styles.css",
+                "url": "styles.css",
                 "destination": "src/styles.css"
             },
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/reactFunctional/detailCellRenderer.jsx",
+                "url": "detailCellRenderer.jsx",
                 "destination": "src/detailCellRenderer.jsx"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/App.js",
-            "src/App.css",
-            "src/App.test.js",
-            "src/logo.svg",
-            "src/index.css"
         ]
     },
     "angular": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/angular/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/angular/app/app.component.ts",
-                "destination": "src/app/app.component.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/angular/app/app.module.ts",
-                "destination": "src/app/app.module.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/angular/styles.css",
+                "url": "styles.css",
                 "destination": "src/app/app.component.css"
             },
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/angular/app/detail-cell-renderer.component.ts",
+                "url": "app/detail-cell-renderer.component.ts",
                 "destination": "src/app/detail-cell-renderer.component.ts"
             },
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/angular/app/interfaces.ts",
+                "url": "app/interfaces.ts",
                 "destination": "src/app/interfaces.ts"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/app/app.component.html",
-            "src/app/app.component.scss"
         ]
     },
     "vue": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vue/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vue/main.js",
-                "destination": "src/main.js"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vue/styles.css",
+                "url": "styles.css",
                 "destination": "public/styles.css"
             },
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vue/detailCellRendererVue.js",
+                "url": "detailCellRendererVue.js",
                 "destination": "src/detailCellRendererVue.js"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/assets",
-            "src/components",
-            "src/App.vue"
         ]
     },
     "vanilla": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vanilla/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vanilla/main.js",
-                "destination": "src/index.js"
+                "url":"detailCellRenderer.js",
+                "destination":"detailCellRenderer.js"
             },
             {
-                "url": "https://www.ag-grid.com/examples/master-detail-custom-detail/custom-detail-with-grid/packages/vanilla/styles.css",
+                "url": "styles.css",
                 "destination": "styles.css"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/styles.css"
         ]
     }
 }

--- a/docs/metadata/master-detail.json
+++ b/docs/metadata/master-detail.json
@@ -1,65 +1,19 @@
 {
     "angular": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail/simple/packages/angular/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/master-detail/simple/packages/angular/app/app.component.ts",
-                "destination": "src/app/app.component.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail/simple/packages/angular/app/app.module.ts",
-                "destination": "src/app/app.module.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail/simple/packages/angular/app/interfaces.ts",
+                "url": "app/interfaces.ts",
                 "destination": "src/app/interfaces.ts"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/app/app.component.html",
-            "src/app/app.component.scss"
         ]
     },
     "react": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail/simple/packages/reactFunctional/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail/simple/packages/reactFunctional/index.jsx",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/App.js",
-            "src/App.css",
-            "src/App.test.js",
-            "src/logo.svg",
-            "src/index.css"
-        ]
+        "filesToFetch": []
     },
     "vue": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail/simple/packages/vue/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail/simple/packages/vue/main.js",
-                "destination": "src/main.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/assets",
-            "src/components",
-            "src/App.vue"
-        ]
+        "filesToFetch": []
     },
     "vanilla": {
-        "indexHTML": "https://www.ag-grid.com/examples/master-detail/simple/packages/vanilla/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/master-detail/simple/packages/vanilla/main.js",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/styles.css"
-        ]
+        "filesToFetch": []
     }
 }

--- a/docs/metadata/range-selection.json
+++ b/docs/metadata/range-selection.json
@@ -1,65 +1,19 @@
 {
     "react": {
-        "indexHTML": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/reactFunctional/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/reactFunctional/index.jsx",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/App.js",
-            "src/App.css",
-            "src/App.test.js",
-            "src/logo.svg",
-            "src/index.css"
-        ]
+        "filesToFetch": []
     },
     "angular": {
-        "indexHTML": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/angular/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/angular/app/app.component.ts",
-                "destination": "src/app/app.component.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/angular/app/app.module.ts",
-                "destination": "src/app/app.module.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/angular/app/interfaces.ts",
+                "url": "app/interfaces.ts",
                 "destination": "src/app/interfaces.ts"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/app/app.component.html",
-            "src/app/app.component.scss"
         ]
     },
     "vue": {
-        "indexHTML": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/vue/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/vue/main.js",
-                "destination": "src/main.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/assets",
-            "src/components",
-            "src/App.vue"
-        ]
+        "filesToFetch": []
     },
     "vanilla": {
-        "indexHTML": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/vanilla/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/range-selection/range-selection/packages/vanilla/main.js",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/styles.css"
-        ]
+        "filesToFetch": []
     }
 }

--- a/docs/metadata/row-grouping.json
+++ b/docs/metadata/row-grouping.json
@@ -1,65 +1,19 @@
 {
     "react": {
-        "indexHTML": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/reactFunctional/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/reactFunctional/index.jsx",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/App.js",
-            "src/App.css",
-            "src/App.test.js",
-            "src/logo.svg",
-            "src/index.css"
-        ]
+        "filesToFetch": []
     },
     "angular": {
-        "indexHTML": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/angular/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/angular/app/app.component.ts",
-                "destination": "src/app/app.component.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/angular/app/app.module.ts",
-                "destination": "src/app/app.module.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/angular/app/interfaces.ts",
+                "url": "app/interfaces.ts",
                 "destination": "src/app/interfaces.ts"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/app/app.component.html",
-            "src/app/app.component.scss"
         ]
     },
     "vue": {
-        "indexHTML": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/vue/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/vue/main.js",
-                "destination": "src/main.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/assets",
-            "src/components",
-            "src/App.vue"
-        ]
+        "filesToFetch": []
     },
     "vanilla": {
-        "indexHTML": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/vanilla/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/grouping/default-row-grouping/packages/vanilla/main.js",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/styles.css"
-        ]
+        "filesToFetch": []
     }
 }

--- a/docs/metadata/server-side-row-model.json
+++ b/docs/metadata/server-side-row-model.json
@@ -1,65 +1,19 @@
 {
     "react": {
-        "indexHTML": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/reactFunctional/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/reactFunctional/index.jsx",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/App.js",
-            "src/App.css",
-            "src/App.test.js",
-            "src/logo.svg",
-            "src/index.css"
-        ]
+        "filesToFetch": []
     },
     "angular": {
-        "indexHTML": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/reactFunctional/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/angular/app/app.component.ts",
-                "destination": "src/app/app.component.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/angular/app/app.module.ts",
-                "destination": "src/app/app.module.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/angular/app/interfaces.ts",
+                "url": "app/interfaces.ts",
                 "destination": "src/app/interfaces.ts"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/app/app.component.html",
-            "src/app/app.component.scss"
         ]
     },
     "vue": {
-        "indexHTML": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/vue/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/vue/main.js",
-                "destination": "src/main.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/assets",
-            "src/components",
-            "src/App.vue"
-        ]
+        "filesToFetch": []
     },
     "vanilla": {
-        "indexHTML": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/vanilla/index.html",
-        "filesToFetch": [
-            {
-                "url": "https://www.ag-grid.com/examples/server-side-model-infinite-scroll/infinite-scroll/packages/vanilla/main.js",
-                "destination": "src/index.js"
-            }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/styles.css"
-        ]
+        "filesToFetch": []
     }
 }

--- a/docs/metadata/tree-data.json
+++ b/docs/metadata/tree-data.json
@@ -1,81 +1,46 @@
 {
     "react": {
-        "indexHTML": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/reactFunctional/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/reactFunctional/index.jsx",
-                "destination": "src/index.js"
+                "url": "styles.css",
+                "destination": "src/styles.css"
             },
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/reactFunctional/style.css",
-                "destination": "src/style.css"
+                "url": "data.js",
+                "destination": "data.js"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/App.js",
-            "src/App.css",
-            "src/App.test.js",
-            "src/logo.svg",
-            "src/index.css"
         ]
     },
     "angular": {
-        "indexHTML": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/angular/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/angular/app/app.component.ts",
-                "destination": "src/app/app.component.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/angular/app/app.module.ts",
-                "destination": "src/app/app.module.ts"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/angular/styles.css",
+                "url": "styles.css",
                 "destination": "src/app/app.component.css"
             },
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/angular/app/data.ts",
+                "url": "app/data.ts",
                 "destination": "src/app/data.ts"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/app/app.component.html",
-            "src/app/app.component.scss"
         ]
     },
     "vue": {
-        "indexHTML": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/vue/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/vue/main.js",
-                "destination": "src/main.js"
-            },
-            {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/vue/styles.css",
+                "url": "styles.css",
                 "destination": "public/styles.css"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/assets",
-            "src/components",
-            "src/App.vue"
         ]
     },
     "vanilla": {
-        "indexHTML": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/vanilla/index.html",
         "filesToFetch": [
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/vanilla/main.js",
-                "destination": "src/index.js"
+                "url": "data.js",
+                "destination": "data.js"
             },
             {
-                "url": "https://www.ag-grid.com/examples/tree-data/org-hierarchy/packages/vanilla/styles.css",
+                "url": "styles.css",
                 "destination": "styles.css"
             }
-        ],
-        "filesToRemoveFromTemplate": [
-            "src/styles.css"
         ]
     }
 }

--- a/scripts/t2-import-docs
+++ b/scripts/t2-import-docs
@@ -40,25 +40,50 @@ echo "importing [$DOCS_EXAMPLE][$FRAMEWORK] example from the AG Grid docs..."
 
 # fetch DOCS_EXAMPLE metadata from t2/docs/metadata directory
 T2_DOCS_METADATA_DIR_PATH="$T2_HOME/docs/metadata"
+T2_DOCS_CORE="$T2_HOME/docs/metadata/docs-core.json"
+
+# returns the framework path for a given framework, e.g. react can be react or reactFunctional
+DOCS_FRAMEWORK_PATH=$(jq -c .$FRAMEWORK'.frameworkPath' $T2_DOCS_CORE)
+
+# get the base URL for the doc example
+DOCS_BASE_URL=$(jq -c '.baseURL'.\""$DOCS_EXAMPLE"\" $T2_DOCS_CORE)
+
+# remove beginning and end quotation marks
+DOCS_FRAMEWORK_PATH=$(gsed -e 's/^"//;s/"$//' <<<$DOCS_FRAMEWORK_PATH)
+DOCS_BASE_URL=$(gsed -e 's/^"//;s/"$//' <<<$DOCS_BASE_URL)
+
+# change to modules link if necessary
+if [ $AG_GRID_INSTALLATION_METHOD == "modules" ]; then
+    DOCS_BASE_URL=$(gsed -e 's/\/packages/\/modules/g' <<<$DOCS_BASE_URL)
+fi
+
+DOCS_BASE_URL="$DOCS_BASE_URL/$DOCS_FRAMEWORK_PATH"
 
 # install jq
 # https://stedolan.github.io/jq/
 
-# iterate over filesToFetch and import them into project
-jq -c .$FRAMEWORK'.filesToFetch[]' $T2_DOCS_METADATA_DIR_PATH/$DOCS_EXAMPLE.json | while read i; do
-    # do stuff with $i
-    docs_url=$(echo "$i" | jq -r '.url')
-    if [ $AG_GRID_INSTALLATION_METHOD == "modules" ]; then
-        docs_url=$(echo "$docs_url" | gsed -e 's/\/packages\//\/modules\//g' )
-    fi
+# fetch files from core
+jq -c .$FRAMEWORK'.filesToFetch[]' $T2_DOCS_CORE | while read i; do
+    file=$(echo "$i" | jq -r '.url')
+    docs_url="$DOCS_BASE_URL/$file"
     destination=$(echo "$i" | jq -r '.destination')
+
     echo "$docs_url > $destination"
     # fetch and import
     curl -o $destination $docs_url
 done
 
+# fetch files for specific example
+jq -c .$FRAMEWORK'.filesToFetch[]' $T2_DOCS_METADATA_DIR_PATH/$DOCS_EXAMPLE.json | while read i; do
+    file=$(echo "$i" | jq -r '.url')
+    docs_url="$DOCS_BASE_URL/$file"
+    destination=$(echo "$i" | jq -r '.destination')
+    echo "$docs_url > $destination"
+    curl -o $destination $docs_url
+done
+
 # iterate over filesToRemoveFromTemplate and delete them
-jq -c .$FRAMEWORK'.filesToRemoveFromTemplate[] | .' $T2_DOCS_METADATA_DIR_PATH/$DOCS_EXAMPLE.json | while read i; do
+jq -c .$FRAMEWORK'.filesToRemoveFromTemplate[] | .' $T2_DOCS_CORE | while read i; do
     # do stuff with $i
     fileToDelete=$(echo "$i" | jq -r)
     # delete file
@@ -66,42 +91,39 @@ jq -c .$FRAMEWORK'.filesToRemoveFromTemplate[] | .' $T2_DOCS_METADATA_DIR_PATH/$
     rm -rf $PWD/$fileToDelete
 done
 
-# inject CSS
 # inject style tags from the docs example's index.html into the project
 echo 'injecting page styles...'
+
 # first fetch the projects index.html file
-jq -c .$FRAMEWORK'.indexHTML' $T2_DOCS_METADATA_DIR_PATH/$DOCS_EXAMPLE.json | while read i; do
-    # create an temporary HTML file where we will output the fetched index.html file
-    URL=$(echo "$i" | jq -r)
-    if [ $AG_GRID_INSTALLATION_METHOD == "modules" ]; then
-        URL=$(echo "$URL" | gsed -e 's/\/packages\//\/modules\//g' )
-    fi
-    curl -o tmp.html $URL
-    # match the <style></style> tags and store them in a variable
-    PAGE_STYLES=$(gsed -n "/<style.*/,/<\/style>/p" tmp.html)
+html_file="$DOCS_BASE_URL/index.html"
 
-    # inject into projects index.html file
-    case "$FRAMEWORK" in
-    'angular')
-        gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/src/index.html"
-        ;;
-    'react')
-        gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/public/index.html"
-        ;;
-    'vue')
-        gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/public/index.html"
-        ;;
-    'vanilla')
-        gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/index.html"
-        ;;
-    *)
-        echo "Could not inject stylesheets"
-        ;;
-    esac
+# create an temporary HTML file where we will output the fetched index.html file
+curl -o tmp.html $html_file
 
-    # delete temporary HTML file
-    rm -rf $PWD/tmp.html
-done
+# match the <style></style> tags and store them in a variable
+PAGE_STYLES=$(gsed -n "/<style.*/,/<\/style>/p" tmp.html)
+
+# inject into projects index.html file
+case "$FRAMEWORK" in
+'angular')
+    gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/src/index.html"
+    ;;
+'react')
+    gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/public/index.html"
+    ;;
+'vue')
+    gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/public/index.html"
+    ;;
+'vanilla')
+    gsed -i "/<\/head>/i $(echo $PAGE_STYLES)" "$PWD/index.html"
+    ;;
+*)
+    echo "Could not inject stylesheets"
+    ;;
+esac
+
+# delete temporary HTML file
+rm -rf $PWD/tmp.html
 
 # ***************************************************
 # ******** FRAMEWORK SPECIFIC MODIFICATIONS *********
@@ -187,8 +209,8 @@ if [[ $DOCS_EXAMPLE == "tree-data" ]]; then
         gsed -i "/selector: 'my-app'/a $TREE_DATA_STYLE_IMPORTS" "$PWD/src/app/app.component.ts"
         ;;
     'react')
-        TREE_DATA_STYLE_IMPORTS="import './style.css'"
-        gsed -i "8a $TREE_DATA_STYLE_IMPORTS" "$PWD/src/index.js"
+        # TREE_DATA_STYLE_IMPORTS="import './style.css'"
+        # gsed -i "8a $TREE_DATA_STYLE_IMPORTS" "$PWD/src/index.js"
         ;;
     'vue')
         TREE_DATA_STYLE_IMPORTS='<link rel="stylesheet" href="styles.css"/>'


### PR DESCRIPTION
FR: #25 

The previous way of adding documentation examples was to add the URL for each file for every example, which made it difficult to refactor as the documentation changed.

Main changes:
- The CLI will dynamically build the URL for each file instead, as long as the Base URL for an example is provided. 
- Created `docs-core.json` which contains similar files for each framework, which will help avoid writing repeated code.

This will help refactor the link to specific doc examples whenever the docs change.


